### PR TITLE
Adding new Compliance status to get_findings function

### DIFF
--- a/files/lambda-artifacts/securityhub-suppressor/securityhub_events.py
+++ b/files/lambda-artifacts/securityhub-suppressor/securityhub_events.py
@@ -17,7 +17,7 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from yaml_parser import get_file_contents
 
 logger = Logger()
-VALID_STATUSES = ['FAILED', 'HIGH']
+VALID_STATUSES = ['FAILED', 'HIGH', 'WARNING']
 DYNAMODB_TABLE_NAME = os.environ['DYNAMODB_TABLE_NAME']
 YAML_CONFIGURATION_FILE = 'suppressor.yml'
 SUPPRESSED_FINDINGS = []

--- a/files/lambda-artifacts/securityhub-suppressor/securityhub_streams.py
+++ b/files/lambda-artifacts/securityhub-suppressor/securityhub_streams.py
@@ -28,7 +28,7 @@ def get_findings(control_value: str) -> Dict[str, list]:
             'Comparison': 'EQUALS'
         }
     ],
-        'ComplianceStatus': [{'Value': 'FAILED', 'Comparison': 'EQUALS'}],
+        'ComplianceStatus': [{'Value': 'FAILED', 'Comparison': 'EQUALS'}, {'Value': 'WARNING', 'Comparison': 'EQUALS'}],
     })
     return {'findings': list(itertools.chain.from_iterable([finding.get('Findings') for finding in findings]))}
 

--- a/files/lambda-artifacts/securityhub-suppressor/securityhub_streams.py
+++ b/files/lambda-artifacts/securityhub-suppressor/securityhub_streams.py
@@ -28,7 +28,16 @@ def get_findings(control_value: str) -> Dict[str, list]:
             'Comparison': 'EQUALS'
         }
     ],
-        'ComplianceStatus': [{'Value': 'FAILED', 'Comparison': 'EQUALS'}, {'Value': 'WARNING', 'Comparison': 'EQUALS'}],
+        'ComplianceStatus': [
+            {
+                'Value': 'FAILED',
+                'Comparison': 'EQUALS'
+            },
+            {
+                'Value': 'WARNING',
+                'Comparison': 'EQUALS'
+            }
+        ],
     })
     return {'findings': list(itertools.chain.from_iterable([finding.get('Findings') for finding in findings]))}
 

--- a/suppressor.tf
+++ b/suppressor.tf
@@ -225,7 +225,7 @@ resource "aws_cloudwatch_event_rule" "securityhub_events_suppressor_failed_event
   "detail": {
     "findings": {
       "Compliance": {
-        "Status": ["FAILED"]
+        "Status": ["FAILED", "WARNING"]
       },
       "Workflow": {
         "Status": ["NEW", "NOTIFIED"]


### PR DESCRIPTION
get_findings function only gathers findings with ComplianceStatus as **FAILED** but there are some findings that also need to be suppressed with ComplianceStatus as **WARNING**