### PR TITLE
fix: remove lambda custom provider

### DIFF
--- a/suppressor.tf
+++ b/suppressor.tf
@@ -152,8 +152,7 @@ module "lambda_suppressor_deployment_package" {
 # Lambda function to suppress Security Hub findings in response to an EventBridge trigger
 module "lambda_securityhub_events_suppressor" {
   #checkov:skip=CKV_AWS_272:Code signing not used for now
-  providers                    = { aws.lambda = aws }
-  source                       = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=v0.3.3"
+  source                       = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=v0.3.14"
   name                         = var.lambda_events_suppressor.name
   create_allow_all_egress_rule = var.create_allow_all_egress_rule
   create_policy                = false
@@ -184,8 +183,7 @@ module "lambda_securityhub_events_suppressor" {
 # Lambda to suppress Security Hub findings in response to DynamoDB stream event
 module "lambda_securityhub_streams_suppressor" {
   #checkov:skip=CKV_AWS_272:Code signing not used for now
-  providers                    = { aws.lambda = aws }
-  source                       = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=v0.3.3"
+  source                       = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=v0.3.14"
   name                         = var.lambda_streams_suppressor.name
   create_allow_all_egress_rule = var.create_allow_all_egress_rule
   create_policy                = false


### PR DESCRIPTION
## Depends on https://github.com/schubergphilis/terraform-aws-mcaf-lambda/pull/60

## what
- Remove lambda custom provider
- Bump version of lambda to new version (pending release)

## why
- This removes the need to provide a `providers = { aws.lambda = aws }` argument for this module and any modules that depend on this module

```hcl
module "mcaf_securityhub_findings_manager" {
  # https://github.com/schubergphilis/terraform-aws-mcaf-securityhub-findings-manager
  # https://registry.terraform.io/modules/schubergphilis/mcaf-securityhub-findings-manager/aws/latest
  source  = "schubergphilis/mcaf-securityhub-findings-manager/aws"
  version = "1.0.0"

  # necessary until the changes in the 2 PRs are merged
  providers = {
    aws = aws
  }

  # ...
}
```

## references
- https://github.com/schubergphilis/terraform-aws-mcaf-lambda/pull/60