### PR TITLE
fix: bump s3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Suppress finding for specific resources:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eventbridge_security_hub_suppressor_role"></a> [eventbridge\_security\_hub\_suppressor\_role](#module\_eventbridge\_security\_hub\_suppressor\_role) | github.com/schubergphilis/terraform-aws-mcaf-role | v0.3.2 |
-| <a name="module_lambda_artifacts_bucket"></a> [lambda\_artifacts\_bucket](#module\_lambda\_artifacts\_bucket) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.6.0 |
+| <a name="module_lambda_artifacts_bucket"></a> [lambda\_artifacts\_bucket](#module\_lambda\_artifacts\_bucket) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.8.0 |
 | <a name="module_lambda_jira_deployment_package"></a> [lambda\_jira\_deployment\_package](#module\_lambda\_jira\_deployment\_package) | terraform-aws-modules/lambda/aws | ~> 3.3.0 |
 | <a name="module_lambda_jira_security_hub"></a> [lambda\_jira\_security\_hub](#module\_lambda\_jira\_security\_hub) | github.com/schubergphilis/terraform-aws-mcaf-lambda | v0.3.3 |
 | <a name="module_lambda_jira_security_hub_role"></a> [lambda\_jira\_security\_hub\_role](#module\_lambda\_jira\_security\_hub\_role) | github.com/schubergphilis/terraform-aws-mcaf-role | v0.3.2 |

--- a/suppressor.tf
+++ b/suppressor.tf
@@ -27,8 +27,10 @@ resource "aws_dynamodb_table" "suppressor_dynamodb_table" {
 module "lambda_artifacts_bucket" {
   #checkov:skip=CKV_AWS_145:Bug in CheckOV https://github.com/bridgecrewio/checkov/issues/3847
   #checkov:skip=CKV_AWS_19:Bug in CheckOV https://github.com/bridgecrewio/checkov/issues/3847
+  source  = "schubergphilis/mcaf-s3/aws"
+  version = "~> 0.11.0"
+
   name        = var.s3_bucket_name
-  source      = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.6.0"
   kms_key_arn = var.kms_key_arn
   logging     = null
   tags        = var.tags


### PR DESCRIPTION
## what
- bump s3 module

## why
- Remove the need for `aws_s3_bucket_acl` which fails if account level restrictions are in place

## references
- Closes #18 