### PR TITLE
fix: Ensure ServiceNow Sync User can update Security Hub findings

### DIFF
--- a/modules/servicenow/main.tf
+++ b/modules/servicenow/main.tf
@@ -1,0 +1,3 @@
+# Data Source to get the access to Account ID in which Terraform is authorized and the region configured on the provider
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}


### PR DESCRIPTION
This PR adds `securityhub:BatchUpdateFindings` and `securityhub:GetFindings` to the ServiceNow Sync User to allow successful sync back of suppressed findings.