### PR TITLE
fix: Reuse variable for zip deployment for python version instead of using 3.8

### DIFF
--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -111,7 +111,7 @@ module "findings_manager_lambda_deployment_package" {
 
   create_function          = false
   recreate_missing_package = false
-  runtime                  = "python3.8"
+  runtime                  = var.findings_manager_events_lambda.runtime
   s3_bucket                = module.findings_manager_bucket.name
   s3_object_storage_class  = "STANDARD"
   source_path              = "${path.module}/files/lambda-artifacts/securityhub-findings-manager"

--- a/jira_lambda.tf
+++ b/jira_lambda.tf
@@ -88,7 +88,7 @@ module "jira_lambda_deployment_package" {
 
   create_function          = false
   recreate_missing_package = false
-  runtime                  = "python3.8"
+  runtime                  = var.jira_integration.lambda_settings.runtime
   s3_bucket                = module.findings_manager_bucket.name
   s3_object_storage_class  = "STANDARD"
   source_path              = "${path.module}/files/lambda-artifacts/findings-manager-jira"


### PR DESCRIPTION
Make the zip deployment use the same runtime as the lambda it is going to run on. Now its runtime was for example by variable set to 3.12 but its packager would use 3.8.