### PR TITLE
fix: updated lambda packages are not uploaded to S3

### DIFF
--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -78,11 +78,12 @@ resource "aws_iam_role_policy_attachment" "findings_manager_lambda_iam_role" {
 
 # Push the Lambda code zip deployment package to s3
 resource "aws_s3_object" "findings_manager_lambdas_deployment_package" {
-  bucket     = module.findings_manager_bucket.id
-  key        = "lambda_securityhub-findings-manager_${var.lambda_runtime}.zip"
-  kms_key_id = var.kms_key_arn
-  source     = "${path.module}/files/pkg/lambda_securityhub-findings-manager_${var.lambda_runtime}.zip"
-  tags       = var.tags
+  bucket      = module.findings_manager_bucket.id
+  key         = "lambda_securityhub-findings-manager_${var.lambda_runtime}.zip"
+  kms_key_id  = var.kms_key_arn
+  source      = "${path.module}/files/pkg/lambda_securityhub-findings-manager_${var.lambda_runtime}.zip"
+  source_hash = filemd5("${path.module}/files/pkg/lambda_securityhub-findings-manager_${var.lambda_runtime}.zip")
+  tags        = var.tags
 }
 
 ################################################################################

--- a/jira_lambda.tf
+++ b/jira_lambda.tf
@@ -83,11 +83,12 @@ resource "aws_iam_role_policy_attachment" "jira_lambda_iam_role_vpc_policy_attac
 resource "aws_s3_object" "jira_lambda_deployment_package" {
   count = var.jira_integration.enabled ? 1 : 0
 
-  bucket     = module.findings_manager_bucket.id
-  key        = "lambda_${var.jira_integration.lambda_settings.name}_${var.lambda_runtime}.zip"
-  kms_key_id = var.kms_key_arn
-  source     = "${path.module}/files/pkg/lambda_findings-manager-jira_${var.lambda_runtime}.zip"
-  tags       = var.tags
+  bucket      = module.findings_manager_bucket.id
+  key         = "lambda_${var.jira_integration.lambda_settings.name}_${var.lambda_runtime}.zip"
+  kms_key_id  = var.kms_key_arn
+  source      = "${path.module}/files/pkg/lambda_findings-manager-jira_${var.lambda_runtime}.zip"
+  source_hash = filemd5("${path.module}/files/pkg/lambda_findings-manager-jira_${var.lambda_runtime}.zip")
+  tags        = var.tags
 }
 
 # Lambda function to create Jira ticket for Security Hub findings and set the workflow state to NOTIFIED


### PR DESCRIPTION
Because of missing hash checks in
 - resource "aws_s3_object" "findings_manager_lambdas_deployment_package"
 - resource "aws_s3_object" "jira_lambda_deployment_package"

updated package would not be uploaded to S3 and as a consequence not update the lambda.

This PR adds an source_hash to ensure that it gets updated.