### PR TITLE
fix: reduce jira lambda executions when autoclose is enabled

### DIFF
--- a/files/step-function-artifacts/securityhub-findings-manager-orchestrator.json.tpl
+++ b/files/step-function-artifacts/securityhub-findings-manager-orchestrator.json.tpl
@@ -86,8 +86,24 @@
               {
                 "Or": [
                   {
-                    "Variable": "$.detail.findings[0].Workflow.Status",
-                    "StringEquals": "NEW"
+                    "And": [
+                      {
+                        "Variable": "$.detail.findings[0].Workflow.Status",
+                        "StringEquals": "NEW"
+                      },
+                      {
+                        "Or": [
+                          {
+                            "Variable": "$.detail.findings[0].Compliance.Status",
+                            "StringEquals": "FAILED"
+                          },
+                          {
+                            "Variable": "$.detail.findings[0].Compliance.Status",
+                            "StringEquals": "WARNING"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "And": [


### PR DESCRIPTION
With the last change (https://github.com/schubergphilis/terraform-aws-mcaf-securityhub-findings-manager/pull/52) when the autoclose is enabled, the Jira integration lambda would get triggered for findings with Workflow Status "NEW" and Compliance Status "NOT_AVAILABLE", this wouldn't create a ticket since it's filtered in the code but results in unnecessary lambda executions.

This PR filters out these findings in the step function, resulting in less executions.