### PR TITLE
fix: Jira close ticket step function definition update

### DIFF
--- a/files/step-function-artifacts/securityhub-findings-manager-orchestrator.json.tpl
+++ b/files/step-function-artifacts/securityhub-findings-manager-orchestrator.json.tpl
@@ -78,15 +78,16 @@
                   }
                 ]
               },
-              {
-                "Variable": "$.detail.findings[0].Severity.Normalized",
-                "NumericGreaterThanEquals": ${finding_severity_normalized}
-              },
               %{~ if jira_autoclose_enabled }
               {
                 "Or": [
                   {
+                    "Comment": "CREATE JIRA TICKET: Requires severity >= threshold",
                     "And": [
+                      {
+                        "Variable": "$.detail.findings[0].Severity.Normalized",
+                        "NumericGreaterThanEquals": ${finding_severity_normalized}
+                      },
                       {
                         "Variable": "$.detail.findings[0].Workflow.Status",
                         "StringEquals": "NEW"
@@ -126,6 +127,7 @@
                     ]
                   },
                   {
+                    "Comment": "CLOSE JIRA TICKET: Works at ANY severity (ticket already exists)",
                     "And": [
                       {
                         "Or": [
@@ -185,8 +187,16 @@
               }
               %{ else }
               {
-                "Variable": "$.detail.findings[0].Workflow.Status",
-                "StringEquals": "NEW"
+                "And": [
+                  {
+                    "Variable": "$.detail.findings[0].Severity.Normalized",
+                    "NumericGreaterThanEquals": ${finding_severity_normalized}
+                  },
+                  {
+                    "Variable": "$.detail.findings[0].Workflow.Status",
+                    "StringEquals": "NEW"
+                  }
+                ]
               }
               %{ endif ~}
             ],


### PR DESCRIPTION
## :hammer_and_wrench: Summary

1. Fixed a logic flaw in the Step Function orchestrator that prevented Jira tickets from being automatically closed when Security Hub findings were resolved but had changed to a lower severity level.

## :rocket: Motivation

1. When Jira auto-close is enabled, the Step Function was incorrectly applying the severity threshold check to both ticket creation and ticket closure operations. This caused the following issue:

a. A HIGH severity finding (Normalized: 70) is detected → Jira ticket created  ✅ 
b. The issue is remediated and the finding is resolved
c. Security Hub changes the finding to INFORMATIONAL (Normalized: 0) with status NOTIFIED/ARCHIVED
d. The Step Function evaluates the severity check (≥ 70) → FAILS
e. The auto-close logic is never reached → Jira ticket remains open  ❌ 

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
