### PR TITLE
feat: prevent informational checks sent to findings manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,15 @@ A lambda layer provides aws-lambda-powertools. To have these dependencies locall
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_event_rule.securityhub_findings_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.securityhub_findings_resolved_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.findings_manager_events_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.findings_manager_events_lambda_resolved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.jira_orchestrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.jira_orchestrator_resolved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.log_group_jira_orchestrator_sfn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_lambda_event_source_mapping.sqs_to_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_permission.eventbridge_invoke_findings_manager_events_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_lambda_permission.eventbridge_invoke_findings_manager_events_lambda_resolved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.s3_invoke_findings_manager_trigger_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.findings_manager_trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_object.findings_manager_lambdas_deployment_package](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |

--- a/README.md
+++ b/README.md
@@ -115,13 +115,11 @@ A lambda layer provides aws-lambda-powertools. To have these dependencies locall
 | [aws_cloudwatch_event_rule.securityhub_findings_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.securityhub_findings_resolved_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.findings_manager_events_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_event_target.findings_manager_events_lambda_resolved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.jira_orchestrator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.jira_orchestrator_resolved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.log_group_jira_orchestrator_sfn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_lambda_event_source_mapping.sqs_to_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping) | resource |
 | [aws_lambda_permission.eventbridge_invoke_findings_manager_events_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
-| [aws_lambda_permission.eventbridge_invoke_findings_manager_events_lambda_resolved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.s3_invoke_findings_manager_trigger_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket_notification.findings_manager_trigger](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_object.findings_manager_lambdas_deployment_package](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |

--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -196,28 +196,12 @@ resource "aws_lambda_permission" "eventbridge_invoke_findings_manager_events_lam
   source_arn    = aws_cloudwatch_event_rule.securityhub_findings_events.arn
 }
 
-resource "aws_lambda_permission" "eventbridge_invoke_findings_manager_events_lambda_resolved" {
-  count = var.jira_integration.enabled && var.jira_integration.autoclose_enabled ? 0 : 1
-
-  action        = "lambda:InvokeFunction"
-  function_name = var.findings_manager_events_lambda.name
-  principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[0].arn
-}
-
 # Add Security Hub Events Lambda function as a target to the EventBridge rule
 resource "aws_cloudwatch_event_target" "findings_manager_events_lambda" {
   count = var.jira_integration.enabled ? 0 : 1
 
   arn  = module.findings_manager_events_lambda.arn
   rule = aws_cloudwatch_event_rule.securityhub_findings_events.name
-}
-
-resource "aws_cloudwatch_event_target" "findings_manager_events_lambda_resolved" {
-  count = var.jira_integration.enabled && var.jira_integration.autoclose_enabled ? 0 : 1
-
-  arn  = module.findings_manager_events_lambda.arn
-  rule = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[0].name
 }
 
 ################################################################################

--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -194,7 +194,7 @@ resource "aws_lambda_permission" "eventbridge_invoke_findings_manager_events_lam
 }
 
 resource "aws_lambda_permission" "eventbridge_invoke_findings_manager_events_lambda_resolved" {
-  count = var.jira_integration.enabled ? 0 : 1
+  count = var.jira_integration.enabled && var.jira_integration.autoclose_enabled ? 0 : 1
 
   action        = "lambda:InvokeFunction"
   function_name = var.findings_manager_events_lambda.name
@@ -211,7 +211,7 @@ resource "aws_cloudwatch_event_target" "findings_manager_events_lambda" {
 }
 
 resource "aws_cloudwatch_event_target" "findings_manager_events_lambda_resolved" {
-  count = var.jira_integration.enabled ? 0 : 1
+  count = var.jira_integration.enabled && var.jira_integration.autoclose_enabled ? 0 : 1
 
   arn  = module.findings_manager_events_lambda.arn
   rule = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[count.index].name

--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -1,7 +1,3 @@
-locals {
-  workflow_status_filter = var.jira_integration.autoclose_enabled ? ["NEW", "NOTIFIED", "RESOLVED"] : ["NEW", "NOTIFIED"]
-}
-
 data "aws_iam_policy_document" "findings_manager_lambda_iam_role" {
   statement {
     sid = "TrustEventsToStoreLogEvent"

--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -158,7 +158,7 @@ EOF
 }
 
 resource "aws_cloudwatch_event_rule" "securityhub_findings_resolved_events" {
-  count       = var.jira_integration.autoclose_enabled ? 1 : 0
+  count       = var.jira_integration.enabled && var.jira_integration.autoclose_enabled ? 1 : 0
   name        = "rule-resolved-${var.findings_manager_events_lambda.name}"
   description = "EventBridge rule for transiting resolved messages, triggering the findings manager events lambda."
   tags        = var.tags

--- a/jira_step_function.tf
+++ b/jira_step_function.tf
@@ -132,7 +132,7 @@ resource "aws_cloudwatch_event_target" "jira_orchestrator" {
 }
 
 resource "aws_cloudwatch_event_target" "jira_orchestrator_resolved" {
-  count = var.jira_integration.enabled ? 1 : 0
+  count = var.jira_integration.enabled && var.jira_integration.autoclose_enabled ? 1 : 0
 
   arn      = aws_sfn_state_machine.jira_orchestrator[0].arn
   role_arn = module.jira_eventbridge_iam_role[0].arn

--- a/jira_step_function.tf
+++ b/jira_step_function.tf
@@ -136,5 +136,5 @@ resource "aws_cloudwatch_event_target" "jira_orchestrator_resolved" {
 
   arn      = aws_sfn_state_machine.jira_orchestrator[0].arn
   role_arn = module.jira_eventbridge_iam_role[0].arn
-  rule     = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[count.index].name
+  rule     = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[0].name
 }

--- a/jira_step_function.tf
+++ b/jira_step_function.tf
@@ -130,3 +130,11 @@ resource "aws_cloudwatch_event_target" "jira_orchestrator" {
   role_arn = module.jira_eventbridge_iam_role[0].arn
   rule     = aws_cloudwatch_event_rule.securityhub_findings_events.name
 }
+
+resource "aws_cloudwatch_event_target" "jira_orchestrator_resolved" {
+  count = var.jira_integration.enabled ? 1 : 0
+
+  arn      = aws_sfn_state_machine.jira_orchestrator[0].arn
+  role_arn = module.jira_eventbridge_iam_role[0].arn
+  rule     = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[count.index].name
+}


### PR DESCRIPTION
## :hammer_and_wrench: Summary

<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
<!-- You can include the GitHub generated Summary, be sure to review and clean up appropriately. -->

This PR fixes the amount of noise being generated by Security Hub compliance checks. It does this by splitting the single eventbridge rule into two different rules, one focusing on actual findings, and the other on resolved messages (when jira autoclose is enabled)



## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

The eventbridge rule currently forwards all events from SecurityHub to either the SecHub Manager lambda, or to the Step function if Jira integration is enabled.

When Jira integration is enabled, the problem comes through because informational checks (Config checks when resources change), are usually also raised in SecurityHub. this causes quite a bit of noise i.e the below is an example control check finding. 

```
{
    "version": "0",
    "id": "ce07b5d0-5393-1077-6f10-9079a9cf3d20",
    "detail-type": "Security Hub Findings - Imported",
    "source": "aws.securityhub",
...
    "region": "eu-central-1",
...
    "detail": {
        "findings": [
            {
                "ProductArn": "arn:aws:securityhub:eu-central-1::product/aws/securityhub",
                "Types": [
                    "Software and Configuration Checks/Industry and Regulatory Standards"
                ],
                "Description": "This AWS control checks whether the default version of AWS Identity and Access Management (IAM) policies (also known as customer managed policies) do not have administrator access with a statement that has \"Effect\": \"Allow\" with \"Action\": \"*\" over \"Resource\": \"*\". It only checks for the Customer Managed Policies that you created, but not inline and AWS Managed Policies.",
                "Compliance": {
                    "Status": "PASSED",
                    "SecurityControlId": "IAM.1",
...
                "ProductName": "Security Hub",
                "FirstObservedAt": "2025-12-29T08:46:16.151Z",
                "CreatedAt": "2025-12-29T08:46:49.806Z",
                "LastObservedAt": "2025-12-29T08:46:16.151Z",
...
                    "Severity": {
                        "Normalized": 0,
                        "Label": "INFORMATIONAL",
                        "Original": "INFORMATIONAL"
                    }
                },
                "ProductFields": {
...
                },
                "Remediation": {
                    "Recommendation": {
                        "Text": "For information on how to correct this issue, consult the AWS Security Hub controls documentation.",
                        "Url": "https://docs.aws.amazon.com/console/securityhub/IAM.1/remediation"
                    }
                },
...
                "RecordState": "ACTIVE",
                "Title": "IAM policies should not allow full \"*\" administrative privileges",
                "Workflow": {
                    "Status": "RESOLVED"
                },
                "Severity": {
                    "Normalized": 0,
                    "Label": "INFORMATIONAL",
                    "Original": "INFORMATIONAL"
                },
                "UpdatedAt": "2025-12-29T08:46:49.806Z",
                "WorkflowState": "NEW",
...
                "ProcessedAt": "2025-12-29T08:46:55.277Z"
            }
        ]
    }
}
```

Since we have a step function workflow, not only do we trigger a step function for every single compliance check, we also send every single compliance check (whether its a finding or not) to the sechub manager or the step function. This change should filter out these messages and:

1. Only send actual findings
2. Only send actual resolved findings (not informational information)

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
