### PR TITLE
Prevent duplicate jira issue creation

### DIFF
--- a/files/step-function-artifacts/securityhub-findings-manager-orchestrator.json.tpl
+++ b/files/step-function-artifacts/securityhub-findings-manager-orchestrator.json.tpl
@@ -95,7 +95,7 @@
               {
                 "Or": [
                   {
-                    "Comment": "CREATE JIRA TICKET: Requires severity >= threshold",
+                    "Comment": "CREATE JIRA TICKET: Requires severity >= threshold AND no existing Jira issue",
                     "And": [
                       {
                         "Variable": "$.detail.findings[0].Severity.Normalized",
@@ -136,6 +136,21 @@
                             ]
                           }
                         ]
+                      },
+                      {
+                        "Comment": "Prevent duplicate Jira creation: Ensure no existing jiraIssue in Note",
+                        "Not": {
+                          "And": [
+                            {
+                              "Variable": "$.detail.findings[0].Note.Text",
+                              "IsPresent": true
+                            },
+                            {
+                              "Variable": "$.detail.findings[0].Note.Text",
+                              "StringMatches": "*jiraIssue*"
+                            }
+                          ]
+                        }
                       }
                     ]
                   },


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Prevents duplicate Jira ticket creation when Security Hub findings transition from `NOTIFIED` back to `NEW` status by adding checks for existing `jiraIssue` references in finding Notes.

## :rocket: Motivation

Currently, when a finding is remediated and later becomes non-compliant again, Security Hub changes the workflow status from `NOTIFIED` back to `NEW`. The system was creating duplicate Jira tickets in these scenarios because:

The Step Function only checked `Workflow.Status == "NEW"` without verifying if a Jira issue already existed.
The Lambda code didn't validate whether the finding already had a linked Jira issue in its Note field.
This resulted in multiple Jira tickets being created for the same Security Hub finding, causing:

Confusion for teams tracking remediation efforts
Wasted time triaging duplicate tickets
Inaccurate metrics on finding counts vs. ticket counts


## :pencil: Additional Information

### Step Function (securityhub-findings-manager-orchestrator.json.tpl)

Added condition to check for absence of jiraIssue in Note.Text before creating tickets
Prevents Lambda invocation for findings with existing Jira references

### Lambda (findings_manager_jira.py)

Added duplicate detection logic that checks for existing jiraIssue key in finding Notes
Logs and skips ticket creation when a Jira issue is already linked
Provides defense-in-depth protection if Step Function filter is bypassed
