### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A lambda layer provides aws-lambda-powertools. To have these dependencies locall
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
@@ -108,19 +108,19 @@ A lambda layer provides aws-lambda-powertools. To have these dependencies locall
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_findings_manager_bucket"></a> [findings\_manager\_bucket](#module\_findings\_manager\_bucket) | schubergphilis/mcaf-s3/aws | ~> 0.14.1 |
-| <a name="module_findings_manager_events_lambda"></a> [findings\_manager\_events\_lambda](#module\_findings\_manager\_events\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 1.4.1 |
-| <a name="module_findings_manager_trigger_lambda"></a> [findings\_manager\_trigger\_lambda](#module\_findings\_manager\_trigger\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 1.4.1 |
-| <a name="module_findings_manager_worker_lambda"></a> [findings\_manager\_worker\_lambda](#module\_findings\_manager\_worker\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 1.4.1 |
-| <a name="module_jira_eventbridge_iam_role"></a> [jira\_eventbridge\_iam\_role](#module\_jira\_eventbridge\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.3.2 |
-| <a name="module_jira_lambda"></a> [jira\_lambda](#module\_jira\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 1.4.1 |
-| <a name="module_jira_step_function_iam_role"></a> [jira\_step\_function\_iam\_role](#module\_jira\_step\_function\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.3.2 |
+| <a name="module_findings_manager_bucket"></a> [findings\_manager\_bucket](#module\_findings\_manager\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
+| <a name="module_findings_manager_events_lambda"></a> [findings\_manager\_events\_lambda](#module\_findings\_manager\_events\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
+| <a name="module_findings_manager_trigger_lambda"></a> [findings\_manager\_trigger\_lambda](#module\_findings\_manager\_trigger\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
+| <a name="module_findings_manager_worker_lambda"></a> [findings\_manager\_worker\_lambda](#module\_findings\_manager\_worker\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
+| <a name="module_jira_eventbridge_iam_role"></a> [jira\_eventbridge\_iam\_role](#module\_jira\_eventbridge\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.5.3 |
+| <a name="module_jira_lambda"></a> [jira\_lambda](#module\_jira\_lambda) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
+| <a name="module_jira_step_function_iam_role"></a> [jira\_step\_function\_iam\_role](#module\_jira\_step\_function\_iam\_role) | schubergphilis/mcaf-role/aws | ~> 0.5.3 |
 | <a name="module_servicenow_integration"></a> [servicenow\_integration](#module\_servicenow\_integration) | ./modules/servicenow/ | n/a |
 
 ## Resources
@@ -167,6 +167,7 @@ A lambda layer provides aws-lambda-powertools. To have these dependencies locall
 | <a name="input_jira_integration"></a> [jira\_integration](#input\_jira\_integration) | Findings Manager - Jira integration settings | <pre>object({<br/>    # Global settings for all jira instances<br/>    autoclose_comment                     = optional(string, "Security Hub finding has been resolved. Autoclosing the issue.")<br/>    autoclose_enabled                     = optional(bool, false)<br/>    autoclose_suppressed_findings         = optional(bool, false)<br/>    autoclose_transition_name             = optional(string, "Close Issue")<br/>    exclude_account_ids                   = optional(list(string), [])<br/>    finding_severity_normalized_threshold = optional(number, 70)<br/>    include_product_names                 = optional(list(string), [])<br/><br/>    security_group_egress_rules = optional(list(object({<br/>      cidr_ipv4                    = optional(string)<br/>      cidr_ipv6                    = optional(string)<br/>      description                  = string<br/>      from_port                    = optional(number, 0)<br/>      ip_protocol                  = optional(string, "-1")<br/>      prefix_list_id               = optional(string)<br/>      referenced_security_group_id = optional(string)<br/>      to_port                      = optional(number, 0)<br/>    })), [])<br/><br/>    lambda_settings = optional(object({<br/>      name        = optional(string, "securityhub-findings-manager-jira")<br/>      log_level   = optional(string, "ERROR")<br/>      memory_size = optional(number, 256)<br/>      timeout     = optional(number, 60)<br/>    }), {})<br/><br/>    step_function_settings = optional(object({<br/>      log_level = optional(string, "ERROR")<br/>      retention = optional(number, 90)<br/>    }), {})<br/><br/>    # Per-instance configurations<br/>    instances = optional(map(object({<br/>      enabled                         = optional(bool, true)<br/>      credentials_secretsmanager_arn  = optional(string)<br/>      credentials_ssm_secret_arn      = optional(string)<br/>      default_instance                = optional(bool, false)<br/>      include_account_ids             = optional(list(string), [])<br/>      include_intermediate_transition = optional(string)<br/>      issue_custom_fields             = optional(map(string), {})<br/>      issue_type                      = optional(string, "Security Advisory")<br/>      project_key                     = string<br/>    })), {})<br/>  })</pre> | `null` | no |
 | <a name="input_jira_step_function_iam_role_name"></a> [jira\_step\_function\_iam\_role\_name](#input\_jira\_step\_function\_iam\_role\_name) | The name of the role which will be assumed by AWS Step Function for Jira integration | `string` | `"SecurityHubFindingsManagerJiraStepFunction"` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | The version of Python to use for the Lambda functions | `string` | `"python3.12"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where the resources will be created. If omitted, the default provider region is used. | `string` | `null` | no |
 | <a name="input_rules_filepath"></a> [rules\_filepath](#input\_rules\_filepath) | Pathname to the file that stores the manager rules | `string` | `""` | no |
 | <a name="input_rules_s3_object_name"></a> [rules\_s3\_object\_name](#input\_rules\_s3\_object\_name) | The S3 object containing the rules to be applied to Security Hub findings manager | `string` | `"rules.yaml"` | no |
 | <a name="input_servicenow_integration"></a> [servicenow\_integration](#input\_servicenow\_integration) | ServiceNow integration settings | <pre>object({<br/>    enabled                   = optional(bool, false)<br/>    create_access_keys        = optional(bool, false)<br/>    cloudwatch_retention_days = optional(number, 365)<br/>    severity_label_filter     = optional(list(string), [])<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,12 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v7.0.0
+
+### Key Changes v7.0.0
+
+This module now requires a minimum AWS provider version of 6.0 to support the region parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+
 ## Upgrading to v6.0.0
 
 The Jira integration has been restructured to support multiple Jira instances. This allows routing Security Hub findings to different Jira projects based on AWS account IDs.
@@ -20,6 +26,7 @@ The Jira integration has been restructured to support multiple Jira instances. T
 The `jira_integration` variable structure has been completely redesigned:
 
 **Old structure:**
+
 ```hcl
 jira_integration = {
   enabled                               = true
@@ -38,6 +45,7 @@ jira_integration = {
 ```
 
 **New structure:**
+
 ```hcl
 jira_integration = {
   autoclose_comment                     = "Closing issue"
@@ -77,7 +85,7 @@ The following variable defaults have been modified:
 - `findings_manager_events_lambda.log_level` -> default: `ERROR` (previous default: `INFO`). The logging configuration has been updated, and `ERROR` is now more logical as the default level.
 - `findings_manager_trigger_lambda.log_level` -> default: `ERROR` (previous default: `INFO`). The logging configuration has been updated, and `ERROR` is now more logical as the default level.
 - `findings_manager_trigger_lambda.memory_size` -> default: `256` (previous default: `1024`). With the new setup, the trigger Lambda requires less memory.
-- `findings_manager_trigger_lambda.timeout` -> default: `300` (previous default: `900`).  With the new setup, the trigger Lambda completes tasks in less time.
+- `findings_manager_trigger_lambda.timeout` -> default: `300` (previous default: `900`). With the new setup, the trigger Lambda completes tasks in less time.
 
 The following variables have been introduced:
 

--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "findings_manager_lambda_iam_role" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "arn:aws:logs:${local.account_region}:${local.account_id}:*"
     ]
   }
 
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "findings_manager_lambda_iam_role" {
       "securityhub:GetFindings"
     ]
     resources = [
-      "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:hub/default"
+      "arn:aws:securityhub:${local.account_region}:${local.account_id}:hub/default"
     ]
   }
 
@@ -82,6 +82,7 @@ resource "aws_s3_object" "findings_manager_lambdas_deployment_package" {
   bucket      = module.findings_manager_bucket.id
   key         = "lambda_securityhub-findings-manager_${var.lambda_runtime}.zip"
   kms_key_id  = var.kms_key_arn
+  region      = var.region
   source      = "${path.module}/files/pkg/lambda_securityhub-findings-manager_${var.lambda_runtime}.zip"
   source_hash = filemd5("${path.module}/files/pkg/lambda_securityhub-findings-manager_${var.lambda_runtime}.zip")
   tags        = var.tags
@@ -95,18 +96,17 @@ resource "aws_s3_object" "findings_manager_lambdas_deployment_package" {
 module "findings_manager_events_lambda" {
   #checkov:skip=CKV_AWS_272:Code signing not used for now
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.4.1"
+  version = "~> 3.0.0"
 
   name                        = var.findings_manager_events_lambda.name
-  create_policy               = true
   create_s3_dummy_object      = false
   description                 = "Lambda to manage Security Hub findings in response to an EventBridge event"
   handler                     = "securityhub_events.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
   log_retention               = 365
   memory_size                 = var.findings_manager_events_lambda.memory_size
-  policy                      = data.aws_iam_policy_document.findings_manager_lambda_iam_role.json
+  region                      = var.region
   runtime                     = var.lambda_runtime
   s3_bucket                   = var.s3_bucket_name
   s3_key                      = aws_s3_object.findings_manager_lambdas_deployment_package.key
@@ -124,12 +124,17 @@ module "findings_manager_events_lambda" {
     POWERTOOLS_LOGGER_LOG_EVENT = "false"
     POWERTOOLS_SERVICE_NAME     = "securityhub-findings-manager-events"
   }
+
+  execution_role = {
+    policy = data.aws_iam_policy_document.findings_manager_lambda_iam_role.json
+  }
 }
 
 # EventBridge Rule that detect Security Hub events
 resource "aws_cloudwatch_event_rule" "securityhub_findings_events" {
   name        = "rule-${var.findings_manager_events_lambda.name}"
   description = "EventBridge rule for detecting Security Hub findings events, triggering the findings manager events lambda."
+  region      = var.region
   tags        = var.tags
 
   event_pattern = <<EOF
@@ -163,6 +168,7 @@ resource "aws_cloudwatch_event_rule" "securityhub_findings_resolved_events" {
 
   name        = "rule-resolved-${var.findings_manager_events_lambda.name}"
   description = "EventBridge rule for transiting resolved and suppressed messages, triggering Jira ticket closure."
+  region      = var.region
   tags        = var.tags
 
   event_pattern = jsonencode({
@@ -194,6 +200,7 @@ resource "aws_lambda_permission" "eventbridge_invoke_findings_manager_events_lam
   action        = "lambda:InvokeFunction"
   function_name = var.findings_manager_events_lambda.name
   principal     = "events.amazonaws.com"
+  region        = var.region
   source_arn    = aws_cloudwatch_event_rule.securityhub_findings_events.arn
 }
 
@@ -201,8 +208,9 @@ resource "aws_lambda_permission" "eventbridge_invoke_findings_manager_events_lam
 resource "aws_cloudwatch_event_target" "findings_manager_events_lambda" {
   count = local.jira_integration_enabled ? 0 : 1
 
-  arn  = module.findings_manager_events_lambda.arn
-  rule = aws_cloudwatch_event_rule.securityhub_findings_events.name
+  arn    = module.findings_manager_events_lambda.arn
+  region = var.region
+  rule   = aws_cloudwatch_event_rule.securityhub_findings_events.name
 }
 
 ################################################################################
@@ -213,18 +221,17 @@ resource "aws_cloudwatch_event_target" "findings_manager_events_lambda" {
 module "findings_manager_trigger_lambda" {
   #checkov:skip=CKV_AWS_272:Code signing not used for now
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.4.1"
+  version = "~> 3.0.0"
 
   name                        = var.findings_manager_trigger_lambda.name
-  create_policy               = true
   create_s3_dummy_object      = false
   description                 = "Lambda to manage Security Hub findings in response to S3 rules file uploads"
   handler                     = "securityhub_trigger.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
   log_retention               = 365
   memory_size                 = var.findings_manager_trigger_lambda.memory_size
-  policy                      = data.aws_iam_policy_document.findings_manager_lambda_iam_role.json
+  region                      = var.region
   runtime                     = var.lambda_runtime
   s3_bucket                   = var.s3_bucket_name
   s3_key                      = aws_s3_object.findings_manager_lambdas_deployment_package.key
@@ -243,6 +250,10 @@ module "findings_manager_trigger_lambda" {
     POWERTOOLS_LOGGER_LOG_EVENT = "false"
     POWERTOOLS_SERVICE_NAME     = "securityhub-findings-manager-trigger"
   }
+
+  execution_role = {
+    policy = data.aws_iam_policy_document.findings_manager_lambda_iam_role.json
+  }
 }
 
 # Allow S3 to invoke S3 Trigger Lambda function
@@ -250,13 +261,15 @@ resource "aws_lambda_permission" "s3_invoke_findings_manager_trigger_lambda" {
   action         = "lambda:InvokeFunction"
   function_name  = var.findings_manager_trigger_lambda.name
   principal      = "s3.amazonaws.com"
-  source_account = data.aws_caller_identity.current.account_id
+  region         = var.region
+  source_account = local.account_id
   source_arn     = module.findings_manager_bucket.arn
 }
 
 # Add Security Hub Trigger Lambda function as a target to rules S3 Object Creation Trigger Events
 resource "aws_s3_bucket_notification" "findings_manager_trigger" {
   bucket = module.findings_manager_bucket.name
+  region = var.region
 
   lambda_function {
     lambda_function_arn = module.findings_manager_trigger_lambda.arn
@@ -276,18 +289,17 @@ resource "aws_s3_bucket_notification" "findings_manager_trigger" {
 module "findings_manager_worker_lambda" {
   #checkov:skip=CKV_AWS_272:Code signing not used for now
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.4.1"
+  version = "~> 3.0.0"
 
   name                        = var.findings_manager_worker_lambda.name
-  create_policy               = true
   create_s3_dummy_object      = false
   description                 = "Lambda to manage Security Hub findings in response to rules on SQS"
   handler                     = "securityhub_trigger_worker.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
   log_retention               = 365
   memory_size                 = var.findings_manager_worker_lambda.memory_size
-  policy                      = data.aws_iam_policy_document.findings_manager_lambda_iam_role.json
+  region                      = var.region
   runtime                     = var.lambda_runtime
   s3_bucket                   = var.s3_bucket_name
   s3_key                      = aws_s3_object.findings_manager_lambdas_deployment_package.key
@@ -303,6 +315,10 @@ module "findings_manager_worker_lambda" {
     POWERTOOLS_LOGGER_LOG_EVENT = "false"
     POWERTOOLS_SERVICE_NAME     = "securityhub-findings-manager-worker"
   }
+
+  execution_role = {
+    policy = data.aws_iam_policy_document.findings_manager_lambda_iam_role.json
+  }
 }
 
 # Upload rules list to S3
@@ -313,6 +329,7 @@ resource "aws_s3_object" "rules" {
   key          = var.rules_s3_object_name
   content_type = "application/x-yaml"
   content      = file(var.rules_filepath)
+  region       = var.region
   source_hash  = filemd5(var.rules_filepath)
   tags         = var.tags
 
@@ -324,6 +341,7 @@ resource "aws_s3_object" "rules" {
 resource "aws_sqs_queue" "findings_manager_rule_q" {
   name                       = "SecurityHubFindingsManagerRuleQueue"
   kms_master_key_id          = var.kms_key_arn
+  region                     = var.region
   visibility_timeout_seconds = var.findings_manager_worker_lambda.timeout
   # Queue visibility timeout needs to >= Function timeout
 }
@@ -331,11 +349,13 @@ resource "aws_sqs_queue" "findings_manager_rule_q" {
 resource "aws_sqs_queue_policy" "findings_manager_rule_sqs_policy" {
   policy    = data.aws_iam_policy_document.findings_manager_rule_sqs_policy_doc.json
   queue_url = aws_sqs_queue.findings_manager_rule_q.id
+  region    = var.region
 }
 
 resource "aws_sqs_queue" "dlq_for_findings_manager_rule_q" {
   name              = "DlqForSecurityHubFindingsManagerRuleQueue"
   kms_master_key_id = var.kms_key_arn
+  region            = var.region
 }
 
 resource "aws_sqs_queue_redrive_policy" "redrive_policy" {
@@ -344,6 +364,7 @@ resource "aws_sqs_queue_redrive_policy" "redrive_policy" {
     deadLetterTargetArn = aws_sqs_queue.dlq_for_findings_manager_rule_q.arn
     maxReceiveCount     = 10
   })
+  region = var.region
 }
 
 resource "aws_sqs_queue_redrive_allow_policy" "dead_letter_allow_policy" {
@@ -353,6 +374,7 @@ resource "aws_sqs_queue_redrive_allow_policy" "dead_letter_allow_policy" {
     redrivePermission = "byQueue",
     sourceQueueArns   = [aws_sqs_queue.findings_manager_rule_q.arn]
   })
+  region = var.region
 }
 
 data "aws_iam_policy_document" "findings_manager_rule_sqs_policy_doc" {
@@ -375,13 +397,15 @@ data "aws_iam_policy_document" "findings_manager_rule_sqs_policy_doc" {
 
 # The SQS queue with rules triggers the worker lambda
 resource "aws_lambda_event_source_mapping" "sqs_to_worker" {
+  enabled          = true
   event_source_arn = aws_sqs_queue.findings_manager_rule_q.arn
   function_name    = module.findings_manager_worker_lambda.name
   # assumes a rule processing time of 30 sec average (which is high)
   batch_size                         = var.findings_manager_worker_lambda.timeout / 30
   maximum_batching_window_in_seconds = 60
+  region                             = var.region
+
   scaling_config {
     maximum_concurrency = 4 #  to prevent Security Hub API rate limits
   }
-  enabled = true
 }

--- a/jira_lambda.tf
+++ b/jira_lambda.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "jira_lambda_iam_role" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "arn:aws:logs:${local.account_region}:${local.account_id}:*"
     ]
   }
 
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "jira_lambda_iam_role" {
       "securityhub:BatchUpdateFindings"
     ]
     resources = [
-      "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:hub/default"
+      "arn:aws:securityhub:${local.account_region}:${local.account_id}:hub/default"
     ]
     condition {
       test     = "ForAnyValue:StringEquals"
@@ -97,6 +97,7 @@ resource "aws_s3_object" "jira_lambda_deployment_package" {
   bucket      = module.findings_manager_bucket.id
   key         = "lambda_${var.jira_integration.lambda_settings.name}_${var.lambda_runtime}.zip"
   kms_key_id  = var.kms_key_arn
+  region      = var.region
   source      = "${path.module}/files/pkg/lambda_findings-manager-jira_${var.lambda_runtime}.zip"
   source_hash = filemd5("${path.module}/files/pkg/lambda_findings-manager-jira_${var.lambda_runtime}.zip")
   tags        = var.tags
@@ -108,18 +109,17 @@ module "jira_lambda" {
   count = local.jira_integration_enabled ? 1 : 0
 
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.4.1"
+  version = "~> 3.0.0"
 
   name                        = var.jira_integration.lambda_settings.name
-  create_policy               = true
   create_s3_dummy_object      = false
   description                 = "Lambda to create jira ticket and set the Security Hub workflow status to notified"
   handler                     = "findings_manager_jira.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${data.aws_region.current.name}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
   log_retention               = 365
   memory_size                 = var.jira_integration.lambda_settings.memory_size
-  policy                      = data.aws_iam_policy_document.jira_lambda_iam_role[0].json
+  region                      = var.region
   runtime                     = var.lambda_runtime
   s3_bucket                   = var.s3_bucket_name
   s3_key                      = aws_s3_object.jira_lambda_deployment_package[0].key
@@ -143,5 +143,9 @@ module "jira_lambda" {
     LOG_LEVEL                   = var.jira_integration.lambda_settings.log_level
     POWERTOOLS_LOGGER_LOG_EVENT = "false"
     POWERTOOLS_SERVICE_NAME     = "securityhub-findings-manager-jira"
+  }
+
+  execution_role = {
+    policy = data.aws_iam_policy_document.jira_lambda_iam_role[0].json
   }
 }

--- a/jira_step_function.tf
+++ b/jira_step_function.tf
@@ -7,7 +7,7 @@ module "jira_step_function_iam_role" {
   count = local.jira_integration_enabled ? 1 : 0
 
   source  = "schubergphilis/mcaf-role/aws"
-  version = "~> 0.3.2"
+  version = "~> 0.5.3"
 
   name                  = var.jira_step_function_iam_role_name
   create_policy         = true
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "jira_step_function_iam_role" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "arn:aws:logs:${local.account_region}:${local.account_id}:*"
     ]
   }
 }
@@ -65,6 +65,7 @@ resource "aws_cloudwatch_log_group" "log_group_jira_orchestrator_sfn" {
   count = local.jira_integration_enabled ? 1 : 0
 
   name              = "/aws/sfn/${local.sfn_jira_orchestrator_name}"
+  region            = var.region
   retention_in_days = var.jira_integration.step_function_settings.retention
   kms_key_id        = var.kms_key_arn
 }
@@ -76,6 +77,7 @@ resource "aws_sfn_state_machine" "jira_orchestrator" {
   count = local.jira_integration_enabled ? 1 : 0
 
   name     = local.sfn_jira_orchestrator_name
+  region   = var.region
   role_arn = module.jira_step_function_iam_role[0].arn
   tags     = var.tags
 
@@ -100,7 +102,7 @@ module "jira_eventbridge_iam_role" {
   count = local.jira_integration_enabled ? 1 : 0
 
   source  = "schubergphilis/mcaf-role/aws"
-  version = "~> 0.3.2"
+  version = "~> 0.5.3"
 
   name                  = var.jira_eventbridge_iam_role_name
   create_policy         = true
@@ -128,6 +130,7 @@ resource "aws_cloudwatch_event_target" "jira_orchestrator" {
   count = local.jira_integration_enabled ? 1 : 0
 
   arn      = aws_sfn_state_machine.jira_orchestrator[0].arn
+  region   = var.region
   role_arn = module.jira_eventbridge_iam_role[0].arn
   rule     = aws_cloudwatch_event_rule.securityhub_findings_events.name
 }
@@ -136,6 +139,7 @@ resource "aws_cloudwatch_event_target" "jira_orchestrator_resolved" {
   count = local.jira_integration_enabled && try(var.jira_integration.autoclose_enabled, false) ? 1 : 0
 
   arn      = aws_sfn_state_machine.jira_orchestrator[0].arn
+  region   = var.region
   role_arn = module.jira_eventbridge_iam_role[0].arn
   rule     = aws_cloudwatch_event_rule.securityhub_findings_resolved_events[0].name
 }

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,8 @@
+locals {
+  account_id     = data.aws_caller_identity.current.account_id
+  account_region = var.region != null ? var.region : data.aws_region.current.region
+}
+
 # Data Source to get the access to Account ID in which Terraform is authorized and the region configured on the provider
 data "aws_caller_identity" "current" {}
-
 data "aws_region" "current" {}

--- a/modules/servicenow/cloudwatch.tf
+++ b/modules/servicenow/cloudwatch.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "servicenow" {
   name              = "/aws/events/servicenow-integration"
+  region            = var.region
   retention_in_days = var.cloudwatch_retention_days
   kms_key_id        = var.kms_key_arn
 }
@@ -32,4 +33,5 @@ data "aws_iam_policy_document" "servicenow" {
 resource "aws_cloudwatch_log_resource_policy" "servicenow" {
   policy_document = data.aws_iam_policy_document.servicenow.json
   policy_name     = "log-delivery-servicenow"
+  region          = var.region
 }

--- a/modules/servicenow/eventbridge.tf
+++ b/modules/servicenow/eventbridge.tf
@@ -1,17 +1,23 @@
 resource "aws_cloudwatch_event_rule" "securityhub" {
   name        = "snow-RuleLifeCycleEvents"
   description = "Send Security Hub imported findings to the AwsServiceManagementConnectorForSecurityHubQueue SQS."
-  event_pattern = templatefile("${path.module}/templates/findings_filter.json.tftpl", {
-  severity_label_filter = jsonencode(var.severity_label_filter) })
+  event_pattern = templatefile("${path.module}/templates/findings_filter.json.tftpl",
+    {
+      severity_label_filter = jsonencode(var.severity_label_filter)
+    }
+  )
+  region = var.region
 }
 
 resource "aws_cloudwatch_event_target" "securityhub" {
   arn       = aws_sqs_queue.servicenow_queue.arn
+  region    = var.region
   rule      = aws_cloudwatch_event_rule.securityhub.name
   target_id = "SendToSQS"
 }
 
 resource "aws_cloudwatch_event_target" "log_group_target" {
-  arn  = aws_cloudwatch_log_group.servicenow.arn
-  rule = aws_cloudwatch_event_rule.securityhub.name
+  arn    = aws_cloudwatch_log_group.servicenow.arn
+  region = var.region
+  rule   = aws_cloudwatch_event_rule.securityhub.name
 }

--- a/modules/servicenow/iam.tf
+++ b/modules/servicenow/iam.tf
@@ -1,11 +1,14 @@
 module "sync-user" {
   #checkov:skip=CKV_AWS_273:We really need a user for this setup
+  source  = "schubergphilis/mcaf-user/aws"
+  version = "1.0.0"
+
   name                  = "SCSyncUser"
-  source                = "github.com/schubergphilis/terraform-aws-mcaf-user?ref=v0.4.0"
   create_iam_access_key = var.create_access_keys
   create_policy         = true
   kms_key_id            = var.kms_key_arn
   policy                = aws_iam_policy.sqs_sechub.policy
+  region                = var.region
   tags                  = var.tags
 
   policy_arns = [
@@ -40,6 +43,6 @@ data "aws_iam_policy_document" "sqs_sechub" {
       "securityhub:BatchUpdateFindings",
       "securityhub:GetFindings"
     ]
-    resources = ["arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:hub/default"]
+    resources = ["arn:aws:securityhub:${local.account_region}:${local.account_id}:hub/default"]
   }
 }

--- a/modules/servicenow/main.tf
+++ b/modules/servicenow/main.tf
@@ -1,3 +1,8 @@
+locals {
+  account_id     = data.aws_caller_identity.current.account_id
+  account_region = var.region != null ? var.region : data.aws_region.current.region
+}
+
 # Data Source to get the access to Account ID in which Terraform is authorized and the region configured on the provider
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}

--- a/modules/servicenow/sqs.tf
+++ b/modules/servicenow/sqs.tf
@@ -1,11 +1,13 @@
 resource "aws_sqs_queue" "servicenow_queue" {
   name              = "AwsServiceManagementConnectorForSecurityHubQueue"
   kms_master_key_id = var.kms_key_arn
+  region            = var.region
 }
 
 resource "aws_sqs_queue_policy" "servicenow" {
   policy    = data.aws_iam_policy_document.servicenow_sqs_policy.json
   queue_url = aws_sqs_queue.servicenow_queue.id
+  region    = var.region
 }
 
 data "aws_iam_policy_document" "servicenow_sqs_policy" {

--- a/modules/servicenow/variables.tf
+++ b/modules/servicenow/variables.tf
@@ -10,15 +10,21 @@ variable "create_access_keys" {
   description = "Whether to create an access_key and secret_access key for the ServiceNow user"
 }
 
+variable "kms_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key used to encrypt the resources"
+}
+
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where the resources will be created. If omitted, the default provider region is used."
+}
+
 variable "severity_label_filter" {
   type        = list(string)
   default     = []
   description = "Only forward findings to ServiceNow with severity labels from this list (by default all severity labels are forwarded)"
-}
-
-variable "kms_key_arn" {
-  type        = string
-  description = "The ARN of the KMS key used to encrypt the resources"
 }
 
 variable "tags" {

--- a/modules/servicenow/versions.tf
+++ b/modules/servicenow/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 6.0"
     }
   }
 }

--- a/s3_bucket.tf
+++ b/s3_bucket.tf
@@ -3,13 +3,13 @@ module "findings_manager_bucket" {
   #checkov:skip=CKV_AWS_145:Bug in CheckOV https://github.com/bridgecrewio/checkov/issues/3847
   #checkov:skip=CKV_AWS_19:Bug in CheckOV https://github.com/bridgecrewio/checkov/issues/3847
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 0.14.1"
+  version = "~> 2.0.0"
 
   name        = var.s3_bucket_name
   kms_key_arn = var.kms_key_arn
   logging     = null
+  region      = var.region
   tags        = var.tags
-  versioning  = true
 
   lifecycle_rule = [
     {

--- a/servicenow.tf
+++ b/servicenow.tf
@@ -8,5 +8,6 @@ module "servicenow_integration" {
   create_access_keys        = var.servicenow_integration.create_access_keys
   severity_label_filter     = var.servicenow_integration.severity_label_filter
   kms_key_arn               = var.kms_key_arn
+  region                    = var.region
   tags                      = var.tags
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -8,7 +8,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 6.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/variables.tf
+++ b/variables.tf
@@ -217,6 +217,12 @@ variable "lambda_runtime" {
   }
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where the resources will be created. If omitted, the default provider region is used."
+}
+
 variable "rules_filepath" {
   type        = string
   default     = ""


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This PR updates the required AWS Provider version to v6.0 and introduces region parameter to allow defining region where the module resources will be deployed without requiring a separate provider configuration.

Also includes bumps to dependencies to facilitate that and/or to include upstream fixes.

## :rocket: Motivation

Support defining deployment region and also solves deprecation warnings for AWS Provider v6 users.

## :pencil: Additional Information

n/a
