### PR TITLE
feat: upgrade AWS Lambda Powertools layer from V2 to V3

### DIFF
--- a/findings_manager.tf
+++ b/findings_manager.tf
@@ -103,7 +103,7 @@ module "findings_manager_events_lambda" {
   description                 = "Lambda to manage Security Hub findings in response to an EventBridge event"
   handler                     = "securityhub_events.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = [local.powertools_layer_arn]
   log_retention               = 365
   memory_size                 = var.findings_manager_events_lambda.memory_size
   region                      = var.region
@@ -229,7 +229,7 @@ module "findings_manager_trigger_lambda" {
   description                 = "Lambda to manage Security Hub findings in response to S3 rules file uploads"
   handler                     = "securityhub_trigger.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = [local.powertools_layer_arn]
   log_retention               = 365
   memory_size                 = var.findings_manager_trigger_lambda.memory_size
   region                      = var.region
@@ -298,7 +298,7 @@ module "findings_manager_worker_lambda" {
   description                 = "Lambda to manage Security Hub findings in response to rules on SQS"
   handler                     = "securityhub_trigger_worker.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = [local.powertools_layer_arn]
   log_retention               = 365
   memory_size                 = var.findings_manager_worker_lambda.memory_size
   region                      = var.region

--- a/jira_lambda.tf
+++ b/jira_lambda.tf
@@ -116,7 +116,7 @@ module "jira_lambda" {
   description                 = "Lambda to create jira ticket and set the Security Hub workflow status to notified"
   handler                     = "findings_manager_jira.lambda_handler"
   kms_key_arn                 = var.kms_key_arn
-  layers                      = ["arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:79"]
+  layers                      = [local.powertools_layer_arn]
   log_retention               = 365
   memory_size                 = var.jira_integration.lambda_settings.memory_size
   region                      = var.region

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,11 @@
 locals {
   account_id     = data.aws_caller_identity.current.account_id
   account_region = var.region != null ? var.region : data.aws_region.current.region
+
+  # Use a AWS provided layer to include Powertools to simplify the redistribution process.
+  # Also see https://docs.powertools.aws.dev/lambda/python/latest/#lambda-layer.
+  # See https://docs.aws.amazon.com/powertools/python/latest/getting-started/install/ for the available layer versions.
+  powertools_layer_arn = "arn:aws:lambda:${local.account_region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-${replace(var.lambda_runtime, ".", "")}-x86_64:27"
 }
 
 # Data Source to get the access to Account ID in which Terraform is authorized and the region configured on the provider

--- a/modules/servicenow/README.md
+++ b/modules/servicenow/README.md
@@ -5,19 +5,19 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sync-user"></a> [sync-user](#module\_sync-user) | github.com/schubergphilis/terraform-aws-mcaf-user | v0.4.0 |
+| <a name="module_sync-user"></a> [sync-user](#module\_sync-user) | schubergphilis/mcaf-user/aws | 1.0.0 |
 
 ## Resources
 
@@ -45,6 +45,7 @@
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | n/a | yes |
 | <a name="input_cloudwatch_retention_days"></a> [cloudwatch\_retention\_days](#input\_cloudwatch\_retention\_days) | Time to retain the CloudWatch Logs for the ServiceNow integration | `number` | `365` | no |
 | <a name="input_create_access_keys"></a> [create\_access\_keys](#input\_create\_access\_keys) | Whether to create an access\_key and secret\_access key for the ServiceNow user | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where the resources will be created. If omitted, the default provider region is used. | `string` | `null` | no |
 | <a name="input_severity_label_filter"></a> [severity\_label\_filter](#input\_severity\_label\_filter) | Only forward findings to ServiceNow with severity labels from this list (by default all severity labels are forwarded) | `list(string)` | `[]` | no |
 
 ## Outputs


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Upgrades all Lambda functions from the AWS Lambda Powertools **V2** layer
(`AWSLambdaPowertoolsPythonV2:79`) to the latest **V3** layer
(`AWSLambdaPowertoolsPythonV3-<runtime>-x86_64:27`).

- Introduced a `local.powertools_layer_arn` in `main.tf` that builds the layer
  ARN dynamically from `var.lambda_runtime`, replacing four duplicated inline
  ARNs across `findings_manager.tf` and `jira_lambda.tf`.
- Verified the Lambda code under `files/lambda-artifacts/` is compatible with
  V3: the only Powertools surface used is `Logger` (incl. `inject_lambda_context`)
  and the `LambdaContext` type import, neither of which has breaking changes in
  V3. All V3 breaking changes affect utilities this code does not import.
